### PR TITLE
Add an ignore_foreign_keys argument for mysqlimport

### DIFF
--- a/client/mysqlimport.c
+++ b/client/mysqlimport.c
@@ -46,7 +46,7 @@ static char *field_escape(char *to,const char *from,uint length);
 static char *add_load_option(char *ptr,const char *object,
 			     const char *statement);
 
-static my_bool	verbose=0,lock_tables=0,ignore_errors=0,opt_delete=0,
+static my_bool  verbose=0,lock_tables=0,ignore_errors=0,opt_delete=0, ignore_foreign_keys=0,
 		replace=0,silent=0,ignore=0,opt_compress=0,
                 opt_low_priority= 0, tty_password= 0;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
@@ -120,6 +120,8 @@ static struct my_option my_long_options[] =
    &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore", 'i', "If duplicate unique key was found, keep old row.",
    &ignore, &ignore, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+  {"ignore-foreign-keys", 'k', "Ignore foreign key checks while importing data.",
+   &ignore_foreign_keys, &ignore_foreign_keys, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-lines", OPT_IGN_LINES, "Ignore first n lines of data infile.",
    &opt_ignore_lines, &opt_ignore_lines, 0, GET_LL,
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -457,6 +459,10 @@ static MYSQL *db_connect(char *host, char *database,
   {
     ignore_errors=0;
     db_error(mysql);
+  }
+  if (ignore_foreign_keys)
+  {
+    mysql_query(mysql, "SET FOREIGN_KEY_CHECKS = 0;");
   }
   return mysql;
 }


### PR DESCRIPTION
I wish I could take credit for this, but I am essentially just applying the diff from the MySQL@Facebook team. 

http://bazaar.launchpad.net/~mysqlatfacebook/mysqlatfacebook/5.1/revision/3459#client/mysqlimport.c
